### PR TITLE
Update swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.8</version>
+        <version>3.4.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.6.0</version>
+            <version>2.8.5</version>
         </dependency>
 
         <!-- Testing -->

--- a/src/main/java/it/aboutbits/springboot/toolbox/swagger/customization/default_not_null/NullableCustomizer.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/swagger/customization/default_not_null/NullableCustomizer.java
@@ -18,8 +18,11 @@ public class NullableCustomizer implements OpenApiCustomizer {
                     if (((Schema<?>) schema).getProperties() != null) {
                         var requiredProperties = new ArrayList<String>();
                         ((Schema<?>) schema).getProperties().forEach((propertyName, property) -> {
-                            if (property.getNullable() == null || !property.getNullable()) {
+                            if (property.getTitle() == null || !property.getTitle().equals("NULLABLE")) {
                                 requiredProperties.add(propertyName);
+                            }
+                            if (property.getTitle() != null && property.getTitle().equals("NULLABLE")) {
+                                property.setTitle(null);
                             }
                         });
                         schema.setRequired(requiredProperties);

--- a/src/main/java/it/aboutbits/springboot/toolbox/swagger/customization/default_not_null/NullablePropertyCustomizer.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/swagger/customization/default_not_null/NullablePropertyCustomizer.java
@@ -31,7 +31,7 @@ public class NullablePropertyCustomizer implements PropertyCustomizer {
 
         if (annotatedType.getCtxAnnotations() != null && Arrays.stream(annotatedType.getCtxAnnotations())
                 .anyMatch(a -> "Nullable".equals(a.annotationType().getSimpleName()))) {
-            property.setNullable(true);
+            property.setTitle("NULLABLE");
         }
 
         return property;


### PR DESCRIPTION
There has been a change in the swagger library that breaks our "nullablility hack".

We want to set all properties to be not-null/required by default. And just those annotated with `@Nullable` should be nullable. Swagger does do it the other way round with no option to change that.

Unfortunately setting the nullablity flag of the property seems to no longer work as it get overwritten at some point. So I changed it to misuse the "title" field to basically do the same thing as before.

Maybe in a future iteration, we could work out something to write json in to the description field to be able to carry more of that metadata in a more controlled way. But for not this should suffice.