### PR TITLE
hotfix type detection

### DIFF
--- a/src/main/java/it/aboutbits/springboot/toolbox/swagger/type/CustomTypePropertyCustomizer.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/swagger/type/CustomTypePropertyCustomizer.java
@@ -33,10 +33,17 @@ public class CustomTypePropertyCustomizer implements PropertyCustomizer {
             }
 
             if (CustomType.class.isAssignableFrom(rawClass)) {
-                @SuppressWarnings("unchecked")
-                var wrappedType = CustomTypeReflectionUtil.getWrappedType(
-                        (Class<? extends CustomType<?>>) rawClass
-                );
+                Class<?> wrappedType = null;
+                if (rawClass.equals(EntityId.class)) {
+                    wrappedType = simpleType.getBindings()
+                            .getTypeParameters()
+                            .getFirst()
+                            .getRawClass();
+                } else {
+                    wrappedType = CustomTypeReflectionUtil.getWrappedType(
+                            (Class<? extends CustomType<?>>) rawClass
+                    );
+                }
 
                 var isIdentity = EntityId.class.isAssignableFrom(rawClass);
 


### PR DESCRIPTION
This is a hotfix that at least fixed the type detection for our current usages.
Type detection of a `CustomType<T>` currently only works when the `T` is set directly and not inherited from a parent's `T`