### PR TITLE
Add support for the UUID type

### DIFF
--- a/src/main/java/it/aboutbits/springboot/toolbox/jackson/CustomTypeDeserializer.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/jackson/CustomTypeDeserializer.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.UUID;
 import java.util.function.Function;
 
 public class CustomTypeDeserializer<T extends CustomType<?>> extends JsonDeserializer<T> {
@@ -91,6 +92,9 @@ public class CustomTypeDeserializer<T extends CustomType<?>> extends JsonDeseria
         }
         if (ScaledBigDecimal.class.isAssignableFrom(wrappedType)) {
             return getScaledBigDecimalConverter();
+        }
+        if (UUID.class.isAssignableFrom(wrappedType)) {
+            return getUUIDConverter();
         }
         throw new CustomTypeDeserializerException("Value type not supported: " + wrappedType.getName());
     }
@@ -215,6 +219,20 @@ public class CustomTypeDeserializer<T extends CustomType<?>> extends JsonDeseria
                 return value.charAt(0);
             } catch (IOException e) {
                 throw new CustomTypeDeserializerException("Failed to read value as Char.", e);
+            }
+        };
+    }
+
+    private static Function<JsonParser, Object> getUUIDConverter() {
+        return jsonParser -> {
+            try {
+                var value = jsonParser.getValueAsString();
+                if (value == null || value.length() != 36) {
+                    throw new IOException();
+                }
+                return UUID.fromString(value);
+            } catch (IOException e) {
+                throw new CustomTypeDeserializerException("Failed to read value as UUID.", e);
             }
         };
     }

--- a/src/main/java/it/aboutbits/springboot/toolbox/persistence/converter/UUIDConverter.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/persistence/converter/UUIDConverter.java
@@ -1,0 +1,27 @@
+package it.aboutbits.springboot.toolbox.persistence.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.UUID;
+
+@Converter
+public class UUIDConverter implements AttributeConverter<UUID, String> {
+    @Override
+    public String convertToDatabaseColumn(UUID attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        return attribute.toString();
+    }
+
+    @Override
+    public UUID convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+
+        return UUID.fromString(dbData);
+    }
+}

--- a/src/main/java/it/aboutbits/springboot/toolbox/persistence/javatype/base/WrappedUUIDJavaType.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/persistence/javatype/base/WrappedUUIDJavaType.java
@@ -1,0 +1,78 @@
+package it.aboutbits.springboot.toolbox.persistence.javatype.base;
+
+import it.aboutbits.springboot.toolbox.type.CustomType;
+import lombok.SneakyThrows;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.AbstractClassJavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Types;
+import java.util.UUID;
+
+public abstract class WrappedUUIDJavaType<T extends CustomType<UUID>> extends AbstractClassJavaType<T> {
+    private final transient Constructor<T> constructor;
+
+    protected WrappedUUIDJavaType(Class<T> type) {
+        super(type);
+
+        try {
+            this.constructor = type.getConstructor(UUID.class);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("No method found for " + type.getName(), e);
+        }
+    }
+
+    @Override
+    public JdbcType getRecommendedJdbcType(JdbcTypeIndicators indicators) {
+        return indicators.getTypeConfiguration()
+                .getJdbcTypeRegistry()
+                .getDescriptor(Types.OTHER);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <X> X unwrap(T id, Class<X> aClass, WrapperOptions wrapperOptions) {
+        var javaTypeClass = getJavaTypeClass();
+
+        if (id == null) {
+            return null;
+        }
+        if (javaTypeClass.isAssignableFrom(aClass)) {
+            return (X) id;
+        }
+        if (UUID.class.isAssignableFrom(aClass)) {
+            return (X) id.value();
+        }
+        if (String.class.isAssignableFrom(aClass)) {
+            return (X) id.value().toString();
+        }
+        if (byte[].class.isAssignableFrom(aClass)) {
+            return (X) id.value().toString().getBytes(StandardCharsets.UTF_8);
+        }
+
+        throw unknownUnwrap(aClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    @SneakyThrows({InstantiationException.class, IllegalAccessException.class, InvocationTargetException.class})
+    @Override
+    public <X> T wrap(X value, WrapperOptions wrapperOptions) {
+        var clazz = getJavaTypeClass();
+
+        if (value == null) {
+            return null;
+        }
+        if (clazz.isInstance(value)) {
+            return (T) value;
+        }
+        if (value instanceof UUID uuidValue) {
+            return constructor.newInstance(uuidValue);
+        }
+
+        throw unknownWrap(value.getClass());
+    }
+}

--- a/src/main/java/it/aboutbits/springboot/toolbox/persistence/javatype/base/WrappedUUIDJavaType.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/persistence/javatype/base/WrappedUUIDJavaType.java
@@ -69,10 +69,15 @@ public abstract class WrappedUUIDJavaType<T extends CustomType<UUID>> extends Ab
         if (clazz.isInstance(value)) {
             return (T) value;
         }
-        if (value instanceof UUID uuidValue) {
-            return constructor.newInstance(uuidValue);
-        }
 
-        throw unknownWrap(value.getClass());
+        return switch (value) {
+            case UUID uuidValue -> constructor.newInstance(uuidValue);
+            case String uuidStringValue -> constructor.newInstance(UUID.fromString(uuidStringValue));
+            case byte[] uuidBytesValue -> constructor.newInstance(UUID.fromString(new String(
+                    uuidBytesValue,
+                    StandardCharsets.UTF_8
+            )));
+            default -> throw unknownWrap(value.getClass());
+        };
     }
 }

--- a/src/main/java/it/aboutbits/springboot/toolbox/swagger/type/CustomTypeModelConverter.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/swagger/type/CustomTypeModelConverter.java
@@ -14,6 +14,7 @@ import lombok.SneakyThrows;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Iterator;
+import java.util.UUID;
 
 public class CustomTypeModelConverter implements ModelConverter {
 
@@ -70,6 +71,9 @@ public class CustomTypeModelConverter implements ModelConverter {
                 }
                 if (Character.class.isAssignableFrom(wrappedType)) {
                     result = context.resolve(new AnnotatedType(Character.TYPE));
+                }
+                if (UUID.class.isAssignableFrom(wrappedType)) {
+                    result = context.resolve(new AnnotatedType(UUID.class));
                 }
 
                 if (result != null) {

--- a/src/main/java/it/aboutbits/springboot/toolbox/swagger/type/CustomTypePropertyCustomizer.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/swagger/type/CustomTypePropertyCustomizer.java
@@ -14,6 +14,7 @@ import org.springdoc.core.customizers.PropertyCustomizer;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.UUID;
 
 @Slf4j
 public class CustomTypePropertyCustomizer implements PropertyCustomizer {
@@ -91,7 +92,7 @@ public class CustomTypePropertyCustomizer implements PropertyCustomizer {
                 }
                 if (BigInteger.class.isAssignableFrom(wrappedType)) {
                     property.type("integer");
-                    property.format("int64");
+                    property.format("");
                     property.setDescription(description);
                     property.setProperties(null);
                     property.set$ref(null);
@@ -142,6 +143,16 @@ public class CustomTypePropertyCustomizer implements PropertyCustomizer {
                     property.format(null);
                     property.minLength(1);
                     property.maxLength(1);
+                    property.setDescription(description);
+                    property.setProperties(null);
+                    property.set$ref(null);
+                    return property;
+                }
+                if (UUID.class.isAssignableFrom(wrappedType)) {
+                    property.type("string");
+                    property.format("uuid");
+                    property.minLength(36);
+                    property.maxLength(36);
                     property.setDescription(description);
                     property.setProperties(null);
                     property.set$ref(null);

--- a/src/main/java/it/aboutbits/springboot/toolbox/web/CustomTypePropertyEditor.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/web/CustomTypePropertyEditor.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.UUID;
 import java.util.function.Function;
 
 public final class CustomTypePropertyEditor<T extends CustomType<?>> extends PropertyEditorSupport {
@@ -99,6 +100,9 @@ public final class CustomTypePropertyEditor<T extends CustomType<?>> extends Pro
         }
         if (ScaledBigDecimal.class.isAssignableFrom(wrappedType)) {
             return ScaledBigDecimal::new;
+        }
+        if (UUID.class.isAssignableFrom(wrappedType)) {
+            return UUID::fromString;
         }
         throw new IllegalArgumentException("Unable to convert text to type: " + wrappedType.getName());
     }

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/CustomTypeBindingsForControllerTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/CustomTypeBindingsForControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithEmailAddress;
 import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithIban;
 import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithScaledBigDecimal;
+import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithUUID;
 import it.aboutbits.springboot.toolbox.support.HttpTest;
 import it.aboutbits.springboot.toolbox.type.EmailAddress;
 import it.aboutbits.springboot.toolbox.type.Iban;
@@ -17,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -161,6 +164,54 @@ public class CustomTypeBindingsForControllerTest {
             );
 
             var actual = objectMapper.readValue(resultAsString, BodyWithScaledBigDecimal.class);
+
+            assertThat(actual).isEqualTo(value);
+        }
+    }
+
+    @Nested
+    class UUIDType {
+        @ParameterizedTest
+        @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+        void UUIDAsPathVariable(String uuidStringValue) throws Exception {
+            var value = UUID.fromString(uuidStringValue);
+
+            var resultAsString = performGetAndReturnResult(
+                    String.format("/test/type/UUID/as-path-variable/%s", value)
+            );
+
+            var actual = objectMapper.readValue(resultAsString, UUID.class);
+
+            assertThat(actual).isEqualTo(value);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+        void UUIDAsRequestParameter(String uuidStringValue) throws Exception {
+            var value = UUID.fromString(uuidStringValue);
+
+            var resultAsString = performGetAndReturnResult(
+                    String.format("/test/type/UUID/as-request-parameter?value=%s", value)
+            );
+
+            var actual = objectMapper.readValue(resultAsString, UUID.class);
+
+            assertThat(actual).isEqualTo(value);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+        void UUIDAsBody(String uuidStringValue) throws Exception {
+            var value = new BodyWithUUID(
+                    UUID.fromString(uuidStringValue)
+            );
+
+            var resultAsString = performPostAndReturnResult(
+                    "/test/type/UUID/as-body",
+                    value
+            );
+
+            var actual = objectMapper.readValue(resultAsString, BodyWithUUID.class);
 
             assertThat(actual).isEqualTo(value);
         }

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/body/BodyWithUUID.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/body/BodyWithUUID.java
@@ -1,0 +1,8 @@
+package it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body;
+
+import java.util.UUID;
+
+public record BodyWithUUID(
+        UUID uuid
+) {
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/controller/CustomTypeTestController.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/controller/CustomTypeTestController.java
@@ -3,6 +3,7 @@ package it.aboutbits.springboot.toolbox.autoconfiguration.mvc.controller;
 import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithEmailAddress;
 import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithIban;
 import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithScaledBigDecimal;
+import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithUUID;
 import it.aboutbits.springboot.toolbox.type.EmailAddress;
 import it.aboutbits.springboot.toolbox.type.Iban;
 import it.aboutbits.springboot.toolbox.type.ScaledBigDecimal;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/test/type")
@@ -59,6 +62,21 @@ public class CustomTypeTestController {
 
     @PostMapping("/ScaledBigDecimal/as-body")
     public BodyWithScaledBigDecimal scaledBigDecimalAsBody(@RequestBody BodyWithScaledBigDecimal value) {
+        return value;
+    }
+
+    @GetMapping("/UUID/as-path-variable/{value}")
+    public UUID uuidAsPathVariable(@PathVariable UUID value) {
+        return value;
+    }
+
+    @GetMapping("/UUID/as-request-parameter")
+    public UUID uuidAsRequestParameter(@RequestParam UUID value) {
+        return value;
+    }
+
+    @PostMapping("/UUID/as-body")
+    public BodyWithUUID uuidAsBody(@RequestBody BodyWithUUID value) {
         return value;
     }
 }

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/CustomTypeJpaTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/CustomTypeJpaTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ApplicationTest
@@ -66,6 +68,41 @@ public class CustomTypeJpaTest {
             var savedItem = repository.save(item);
 
             var retrievedItem = repository.findByAccountBalance(savedItem.getAccountBalance());
+
+            assertThat(retrievedItem).isPresent()
+                    .get()
+                    .usingRecursiveComparison()
+                    .isEqualTo(savedItem);
+        }
+    }
+
+    @Nested
+    class UUIDType {
+        @ParameterizedTest
+        @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+        void inAndOut_shouldSucceed(String uuidStringValue) {
+            var item = new CustomTypeTestModel();
+            item.setUuid(UUID.fromString(uuidStringValue));
+
+            var savedItem = repository.save(item);
+
+            var retrievedItem = repository.findByUuid(savedItem.getUuid());
+
+            assertThat(retrievedItem).isPresent()
+                    .get()
+                    .usingRecursiveComparison()
+                    .isEqualTo(savedItem);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+        void inAndOutString_shouldSucceed(String uuidStringValue) {
+            var item = new CustomTypeTestModel();
+            item.setUuidAsString(UUID.fromString(uuidStringValue));
+
+            var savedItem = repository.save(item);
+
+            var retrievedItem = repository.findByUuidAsString(savedItem.getUuidAsString());
 
             assertThat(retrievedItem).isPresent()
                     .get()

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/CustomTypeTestModel.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/CustomTypeTestModel.java
@@ -1,6 +1,7 @@
 package it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa;
 
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.AutoRegisteredJavaType;
+import it.aboutbits.springboot.toolbox.persistence.converter.UUIDConverter;
 import it.aboutbits.springboot.toolbox.persistence.javatype.EmailAddressJavaType;
 import it.aboutbits.springboot.toolbox.persistence.javatype.IbanJavaType;
 import it.aboutbits.springboot.toolbox.persistence.javatype.ScaledBigDecimalJavaType;
@@ -10,6 +11,7 @@ import it.aboutbits.springboot.toolbox.type.Iban;
 import it.aboutbits.springboot.toolbox.type.ScaledBigDecimal;
 import it.aboutbits.springboot.toolbox.type.identity.EntityId;
 import it.aboutbits.springboot.toolbox.type.identity.Identified;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,6 +20,8 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.JavaType;
+
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -40,6 +44,11 @@ public class CustomTypeTestModel implements Identified<CustomTypeTestModel.ID> {
     @SuppressWarnings("JpaAttributeTypeInspection")
     @JavaType(ScaledBigDecimalJavaType.class)
     private ScaledBigDecimal accountBalance;
+
+    private UUID uuid;
+
+    @Convert(converter = UUIDConverter.class)
+    private UUID uuidAsString;
 
     @JavaType(ReferencedTestModel.ID.JavaType.class)
     private ReferencedTestModel.ID referencedId;

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/CustomTypeTestModelRepository.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/CustomTypeTestModelRepository.java
@@ -6,6 +6,7 @@ import it.aboutbits.springboot.toolbox.type.ScaledBigDecimal;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface CustomTypeTestModelRepository extends JpaRepository<CustomTypeTestModel, CustomTypeTestModel.ID> {
     Optional<CustomTypeTestModel> findByEmail(EmailAddress emailAddress);
@@ -13,6 +14,9 @@ public interface CustomTypeTestModelRepository extends JpaRepository<CustomTypeT
     Optional<CustomTypeTestModel> findByIban(Iban iban);
 
     Optional<CustomTypeTestModel> findByAccountBalance(ScaledBigDecimal accountBalance);
+
+    Optional<CustomTypeTestModel> findByUuid(UUID uuid);
+    Optional<CustomTypeTestModel> findByUuidAsString(UUID uuidAsString);
 
     Optional<CustomTypeTestModel> findByReferencedId(ReferencedTestModel.ID otherId);
 }

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/WrapperTypesJpaTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/WrapperTypesJpaTest.java
@@ -26,6 +26,8 @@ import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapShortC
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapShortRecord;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapStringClass;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapStringRecord;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapUUIDClass;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapUUIDRecord;
 import it.aboutbits.springboot.toolbox.support.ApplicationTest;
 import it.aboutbits.springboot.toolbox.type.ScaledBigDecimal;
 import org.junit.jupiter.api.Nested;
@@ -36,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -453,6 +456,71 @@ public class WrapperTypesJpaTest {
                         .isEqualTo(savedItem);
             }
         }
+
+        @Nested
+        class WrapUUIDRecordType {
+            @Test
+            void givenNull_inAndOut_shouldSucceed() {
+                var item = new WrapperTypesModel();
+                item.setUuidValueClass(null);
+
+                var savedItem = repository.save(item);
+
+                var retrievedItem = repository.findByUuidValue(null);
+
+                assertThat(retrievedItem).isPresent()
+                        .get()
+                        .usingRecursiveComparison()
+                        .isEqualTo(savedItem);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+            void givenValues_inAndOut_shouldSucceed(String uuidStringValue) {
+                var item = new WrapperTypesModel();
+                item.setUuidValue(new WrapUUIDRecord(UUID.fromString(uuidStringValue)));
+
+                var savedItem = repository.save(item);
+
+                var retrievedItem = repository.findByUuidValue(savedItem.getUuidValue());
+
+                assertThat(retrievedItem).isPresent()
+                        .get()
+                        .usingRecursiveComparison()
+                        .isEqualTo(savedItem);
+            }
+
+            @Test
+            void givenNullString_inAndOut_shouldSucceed() {
+                var item = new WrapperTypesModel();
+                item.setUuidValueAsString(null);
+
+                var savedItem = repository.save(item);
+
+                var retrievedItem = repository.findByUuidValueAsString(null);
+
+                assertThat(retrievedItem).isPresent()
+                        .get()
+                        .usingRecursiveComparison()
+                        .isEqualTo(savedItem);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+            void givenStringValues_inAndOut_shouldSucceed(String uuidStringValue) {
+                var item = new WrapperTypesModel();
+                item.setUuidValueAsString(new WrapUUIDRecord(UUID.fromString(uuidStringValue)));
+
+                var savedItem = repository.save(item);
+
+                var retrievedItem = repository.findByUuidValueAsString(savedItem.getUuidValueAsString());
+
+                assertThat(retrievedItem).isPresent()
+                        .get()
+                        .usingRecursiveComparison()
+                        .isEqualTo(savedItem);
+            }
+        }
     }
 
     @Nested
@@ -857,6 +925,71 @@ public class WrapperTypesJpaTest {
                 var savedItem = repository.save(item);
 
                 var retrievedItem = repository.findByBoolValueClass(savedItem.getBoolValueClass());
+
+                assertThat(retrievedItem).isPresent()
+                        .get()
+                        .usingRecursiveComparison()
+                        .isEqualTo(savedItem);
+            }
+        }
+
+        @Nested
+        class WrapUUIDClassType {
+            @Test
+            void givenNull_inAndOut_shouldSucceed() {
+                var item = new WrapperTypesModel();
+                item.setUuidValueClass(null);
+
+                var savedItem = repository.save(item);
+
+                var retrievedItem = repository.findByUuidValueClass(null);
+
+                assertThat(retrievedItem).isPresent()
+                        .get()
+                        .usingRecursiveComparison()
+                        .isEqualTo(savedItem);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+            void givenValues_inAndOut_shouldSucceed(String uuidStringValue) {
+                var item = new WrapperTypesModel();
+                item.setUuidValueClass(new WrapUUIDClass(UUID.fromString(uuidStringValue)));
+
+                var savedItem = repository.save(item);
+
+                var retrievedItem = repository.findByUuidValueClass(savedItem.getUuidValueClass());
+
+                assertThat(retrievedItem).isPresent()
+                        .get()
+                        .usingRecursiveComparison()
+                        .isEqualTo(savedItem);
+            }
+
+            @Test
+            void givenNullString_inAndOut_shouldSucceed() {
+                var item = new WrapperTypesModel();
+                item.setUuidValueClassAsString(null);
+
+                var savedItem = repository.save(item);
+
+                var retrievedItem = repository.findByUuidValueClassAsString(null);
+
+                assertThat(retrievedItem).isPresent()
+                        .get()
+                        .usingRecursiveComparison()
+                        .isEqualTo(savedItem);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"d414ed05-c370-445a-8430-1fd1021c9856", "0682a03d-3618-470f-a8f9-78e4a52f1a2c"})
+            void givenStringValues_inAndOut_shouldSucceed(String uuidStringValue) {
+                var item = new WrapperTypesModel();
+                item.setUuidValueClassAsString(new WrapUUIDClass(UUID.fromString(uuidStringValue)));
+
+                var savedItem = repository.save(item);
+
+                var retrievedItem = repository.findByUuidValueClassAsString(savedItem.getUuidValueClassAsString());
 
                 assertThat(retrievedItem).isPresent()
                         .get()

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/javatype/WrapUUIDClassJavaType.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/javatype/WrapUUIDClassJavaType.java
@@ -1,0 +1,11 @@
+package it.aboutbits.springboot.toolbox.persistence.javatype.impl.javatype;
+
+import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.AutoRegisteredJavaType;
+import it.aboutbits.springboot.toolbox.persistence.javatype.base.WrappedUUIDJavaType;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapUUIDClass;
+
+public final class WrapUUIDClassJavaType extends WrappedUUIDJavaType<WrapUUIDClass> implements AutoRegisteredJavaType<WrapUUIDClass> {
+    public WrapUUIDClassJavaType() {
+        super(WrapUUIDClass.class);
+    }
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/javatype/WrapUUIDRecordJavaType.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/javatype/WrapUUIDRecordJavaType.java
@@ -1,0 +1,11 @@
+package it.aboutbits.springboot.toolbox.persistence.javatype.impl.javatype;
+
+import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.AutoRegisteredJavaType;
+import it.aboutbits.springboot.toolbox.persistence.javatype.base.WrappedUUIDJavaType;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapUUIDRecord;
+
+public final class WrapUUIDRecordJavaType extends WrappedUUIDJavaType<WrapUUIDRecord> implements AutoRegisteredJavaType<WrapUUIDRecord> {
+    public WrapUUIDRecordJavaType() {
+        super(WrapUUIDRecord.class);
+    }
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/jpa/WrapperTypesModel.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/jpa/WrapperTypesModel.java
@@ -26,6 +26,8 @@ import it.aboutbits.springboot.toolbox.persistence.javatype.impl.javatype.WrapSh
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.javatype.WrapShortRecordJavaType;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.javatype.WrapStringClassJavaType;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.javatype.WrapStringRecordJavaType;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.javatype.WrapUUIDClassJavaType;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.javatype.WrapUUIDRecordJavaType;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapBigDecimalClass;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapBigDecimalRecord;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapBigIntegerClass;
@@ -50,6 +52,8 @@ import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapShortC
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapShortRecord;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapStringClass;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapStringRecord;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapUUIDClass;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapUUIDRecord;
 import it.aboutbits.springboot.toolbox.type.identity.EntityId;
 import it.aboutbits.springboot.toolbox.type.identity.Identified;
 import jakarta.persistence.Entity;
@@ -60,6 +64,8 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.JavaType;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 
 @Entity
 @Getter
@@ -120,6 +126,16 @@ public class WrapperTypesModel implements Identified<WrapperTypesModel.ID> {
     private WrapBooleanRecord boolValue;
 
     @SuppressWarnings("JpaAttributeTypeInspection")
+    @JavaType(WrapUUIDRecordJavaType.class)
+    @JdbcType(UUIDJdbcType.class)
+    private WrapUUIDRecord uuidValue;
+
+    @SuppressWarnings("JpaAttributeTypeInspection")
+    @JavaType(WrapUUIDRecordJavaType.class)
+    @JdbcType(UUIDJdbcType.class)
+    private WrapUUIDRecord uuidValueAsString;
+
+    @SuppressWarnings("JpaAttributeTypeInspection")
     @JavaType(WrapBigDecimalClassJavaType.class)
     private WrapBigDecimalClass bigDecimalValueClass;
 
@@ -167,6 +183,15 @@ public class WrapperTypesModel implements Identified<WrapperTypesModel.ID> {
     @JavaType(WrapBooleanClassJavaType.class)
     private WrapBooleanClass boolValueClass;
 
+    @SuppressWarnings("JpaAttributeTypeInspection")
+    @JavaType(WrapUUIDClassJavaType.class)
+    @JdbcType(UUIDJdbcType.class)
+    private WrapUUIDClass uuidValueClass;
+
+    @SuppressWarnings("JpaAttributeTypeInspection")
+    @JavaType(WrapUUIDClassJavaType.class)
+    @JdbcType(UUIDJdbcType.class)
+    private WrapUUIDClass uuidValueClassAsString;
 
     public record ID(
             Long value

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/jpa/WrapperTypesModel.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/jpa/WrapperTypesModel.java
@@ -65,6 +65,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.JavaType;
 import org.hibernate.annotations.JdbcType;
+import org.hibernate.type.descriptor.jdbc.CharJdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 
 @Entity
@@ -132,7 +133,7 @@ public class WrapperTypesModel implements Identified<WrapperTypesModel.ID> {
 
     @SuppressWarnings("JpaAttributeTypeInspection")
     @JavaType(WrapUUIDRecordJavaType.class)
-    @JdbcType(UUIDJdbcType.class)
+    @JdbcType(CharJdbcType.class)
     private WrapUUIDRecord uuidValueAsString;
 
     @SuppressWarnings("JpaAttributeTypeInspection")
@@ -190,7 +191,7 @@ public class WrapperTypesModel implements Identified<WrapperTypesModel.ID> {
 
     @SuppressWarnings("JpaAttributeTypeInspection")
     @JavaType(WrapUUIDClassJavaType.class)
-    @JdbcType(UUIDJdbcType.class)
+    @JdbcType(CharJdbcType.class)
     private WrapUUIDClass uuidValueClassAsString;
 
     public record ID(

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/jpa/WrapperTypesModelRepository.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/jpa/WrapperTypesModelRepository.java
@@ -24,6 +24,8 @@ import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapShortC
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapShortRecord;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapStringClass;
 import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapStringRecord;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapUUIDClass;
+import it.aboutbits.springboot.toolbox.persistence.javatype.impl.type.WrapUUIDRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -53,6 +55,10 @@ public interface WrapperTypesModelRepository extends JpaRepository<WrapperTypesM
 
     Optional<WrapperTypesModel> findByCharValue(WrapCharacterRecord value);
 
+    Optional<WrapperTypesModel> findByUuidValue(WrapUUIDRecord value);
+
+    Optional<WrapperTypesModel> findByUuidValueAsString(WrapUUIDRecord value);
+
     Optional<WrapperTypesModel> findByBigDecimalValueClass(WrapBigDecimalClass value);
 
     Optional<WrapperTypesModel> findByBigIntegerValueClass(WrapBigIntegerClass value);
@@ -76,4 +82,8 @@ public interface WrapperTypesModelRepository extends JpaRepository<WrapperTypesM
     Optional<WrapperTypesModel> findByByteValueClass(WrapByteClass value);
 
     Optional<WrapperTypesModel> findByCharValueClass(WrapCharacterClass value);
+
+    Optional<WrapperTypesModel> findByUuidValueClass(WrapUUIDClass value);
+
+    Optional<WrapperTypesModel> findByUuidValueClassAsString(WrapUUIDClass value);
 }

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/type/WrapUUIDClass.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/type/WrapUUIDClass.java
@@ -1,0 +1,17 @@
+package it.aboutbits.springboot.toolbox.persistence.javatype.impl.type;
+
+import it.aboutbits.springboot.toolbox.type.CustomType;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+import java.util.UUID;
+
+@Getter
+@Accessors(fluent = true)
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class WrapUUIDClass implements CustomType<UUID> {
+    private final UUID value;
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/type/WrapUUIDRecord.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/javatype/impl/type/WrapUUIDRecord.java
@@ -1,0 +1,9 @@
+package it.aboutbits.springboot.toolbox.persistence.javatype.impl.type;
+
+import it.aboutbits.springboot.toolbox.type.CustomType;
+
+import java.util.UUID;
+
+public record WrapUUIDRecord(UUID value) implements CustomType<UUID> {
+
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/persistence/transformer/TupleTransformerTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/persistence/transformer/TupleTransformerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,7 +73,9 @@ public class TupleTransformerTest {
         var tupleTransformer = new TupleTransformer<>(DataRecord.class);
         var l = Long.valueOf(7);
         var b = Boolean.valueOf(true);
-        var objectsUnderTest = new Object[]{l, b, "String123", false, SomeEnum.ENUM_1};
+        var objectsUnderTest = new Object[]{
+                l, b, "String123", false, SomeEnum.ENUM_1, UUID.fromString("f255a993-0086-4b4d-a62f-3aa174501f88")
+        };
 
         // when
         var result = tupleTransformer.transform(objectsUnderTest);
@@ -83,6 +86,7 @@ public class TupleTransformerTest {
         assertThat(result.string).isEqualTo("String123");
         assertThat(result.booleanPrimitive).isFalse();
         assertThat(result.anEnum).isEqualTo(SomeEnum.ENUM_1);
+        assertThat(result.uuid).isEqualTo(UUID.fromString("f255a993-0086-4b4d-a62f-3aa174501f88"));
     }
 
 
@@ -92,7 +96,9 @@ public class TupleTransformerTest {
         var tupleTransformer = new TupleTransformer<>(DataRecord.class);
         var l = Long.valueOf(7);
         var b = Boolean.valueOf(true);
-        var objectsUnderTest = new Object[]{l, b, "String123", false, "ENUM_1"};
+        var objectsUnderTest = new Object[]{
+                l, b, "String123", false, "ENUM_1", UUID.fromString("f255a993-0086-4b4d-a62f-3aa174501f88")
+        };
 
         // when
         var result = tupleTransformer.transform(objectsUnderTest);
@@ -103,6 +109,7 @@ public class TupleTransformerTest {
         assertThat(result.string).isEqualTo("String123");
         assertThat(result.booleanPrimitive).isFalse();
         assertThat(result.anEnum).isEqualTo(SomeEnum.ENUM_1);
+        assertThat(result.uuid).isEqualTo(UUID.fromString("f255a993-0086-4b4d-a62f-3aa174501f88"));
     }
 
 
@@ -110,7 +117,14 @@ public class TupleTransformerTest {
     void createRecordInsideAClass_givenMixedObjects_shouldPass() {
         // given
         var tupleTransformer = new TupleTransformer<>(DataRecordParent.class);
-        var rec = new DataRecord(7L, true, "String123", false, SomeEnum.ENUM_1);
+        var rec = new DataRecord(
+                7L,
+                true,
+                "String123",
+                false,
+                SomeEnum.ENUM_1,
+                UUID.fromString("f255a993-0086-4b4d-a62f-3aa174501f88")
+        );
         var objectsUnderTest = new Object[]{rec, 33};
 
         // when
@@ -122,6 +136,7 @@ public class TupleTransformerTest {
         assertThat(result.dataRecord.string).isEqualTo("String123");
         assertThat(result.dataRecord.booleanPrimitive).isFalse();
         assertThat(result.dataRecord.anEnum).isEqualTo(SomeEnum.ENUM_1);
+        assertThat(result.dataRecord.uuid).isEqualTo(UUID.fromString("f255a993-0086-4b4d-a62f-3aa174501f88"));
         assertThat(result.someOtherField).isEqualTo(33);
     }
 
@@ -130,7 +145,9 @@ public class TupleTransformerTest {
     void createRecord_givenMixedObjects_someNullValues_shouldPass() {
         // given
         var tupleTransformer = new TupleTransformer<>(DataRecord.class);
-        var objectsUnderTest = new Object[]{null, null, "String123", false, null};
+        var objectsUnderTest = new Object[]{
+                null, null, "String123", false, null, UUID.fromString("f255a993-0086-4b4d-a62f-3aa174501f88")
+        };
 
         // when
         var result = tupleTransformer.transform(objectsUnderTest);
@@ -141,6 +158,7 @@ public class TupleTransformerTest {
         assertThat(result.string).isEqualTo("String123");
         assertThat(result.booleanPrimitive).isFalse();
         assertThat(result.anEnum).isNull();
+        assertThat(result.uuid).isEqualTo(UUID.fromString("f255a993-0086-4b4d-a62f-3aa174501f88"));
     }
 
 
@@ -148,8 +166,22 @@ public class TupleTransformerTest {
     void createRecordInsideAClass_givenMixedObjectsAsList_shouldPass() {
         // given
         var tupleTransformer = new TupleTransformer<>(DataRecordParentWithList.class);
-        var rec1 = new DataRecord(7L, true, "String111", false, SomeEnum.ENUM_1);
-        var rec2 = new DataRecord(0L, null, "String222", false, SomeEnum.ENUM_2);
+        var rec1 = new DataRecord(
+                7L,
+                true,
+                "String111",
+                false,
+                SomeEnum.ENUM_1,
+                UUID.fromString("c3221989-b494-4227-b7e1-2f84fdc048f7")
+        );
+        var rec2 = new DataRecord(
+                0L,
+                null,
+                "String222",
+                false,
+                SomeEnum.ENUM_2,
+                UUID.fromString("25f6e0c2-4628-43a1-a703-e80926496fd1")
+        );
         var list = new ArrayList<>();
         list.add(rec1);
         list.add(rec2);
@@ -159,19 +191,21 @@ public class TupleTransformerTest {
         var result = tupleTransformer.transform(objectsUnderTest);
 
         // then
-        var firstRecord = result.dataRecords.get(0);
+        var firstRecord = result.dataRecords.getFirst();
         assertThat(firstRecord.longField).isEqualTo(7L);
         assertThat(firstRecord.booleanBoxed).isTrue();
         assertThat(firstRecord.string).isEqualTo("String111");
         assertThat(firstRecord.booleanPrimitive).isFalse();
         assertThat(firstRecord.anEnum).isEqualTo(SomeEnum.ENUM_1);
+        assertThat(firstRecord.uuid).isEqualTo(UUID.fromString("c3221989-b494-4227-b7e1-2f84fdc048f7"));
 
         var secondRecord = result.dataRecords.get(1);
-        assertThat(secondRecord.longField).isEqualTo(0L);
+        assertThat(secondRecord.longField).isZero();
         assertThat(secondRecord.booleanBoxed).isNull();
         assertThat(secondRecord.string).isEqualTo("String222");
         assertThat(secondRecord.booleanPrimitive).isFalse();
         assertThat(secondRecord.anEnum).isEqualTo(SomeEnum.ENUM_2);
+        assertThat(secondRecord.uuid).isEqualTo(UUID.fromString("25f6e0c2-4628-43a1-a703-e80926496fd1"));
 
         assertThat(result.someOtherField).isEqualTo(33);
     }
@@ -189,7 +223,8 @@ public class TupleTransformerTest {
             Boolean booleanBoxed,
             String string,
             boolean booleanPrimitive,
-            SomeEnum anEnum
+            SomeEnum anEnum,
+            UUID uuid
     ) {
     }
 

--- a/src/test/resources/db/changelog/2024-09-06-create-custom-type-testing-table.yml
+++ b/src/test/resources/db/changelog/2024-09-06-create-custom-type-testing-table.yml
@@ -25,3 +25,9 @@ databaseChangeLog:
               - column:
                   name: referenced_id
                   type: bigint
+              - column:
+                  name: uuid
+                  type: uuid
+              - column:
+                  name: uuid_as_string
+                  type: char(36)

--- a/src/test/resources/db/changelog/2024-09-06-create-wrapper-type-testing-table.yml
+++ b/src/test/resources/db/changelog/2024-09-06-create-wrapper-type-testing-table.yml
@@ -50,6 +50,12 @@ databaseChangeLog:
                   name: bool_value
                   type: boolean
               - column:
+                  name: uuid_value
+                  type: uuid
+              - column:
+                  name: uuid_value_as_string
+                  type: uuid
+              - column:
                   name: big_decimal_value_class
                   type: double
               - column:
@@ -85,3 +91,9 @@ databaseChangeLog:
               - column:
                   name: bool_value_class
                   type: boolean
+              - column:
+                  name: uuid_value_class
+                  type: uuid
+              - column:
+                  name: uuid_value_class_as_string
+                  type: uuid

--- a/src/test/resources/db/changelog/2024-09-06-create-wrapper-type-testing-table.yml
+++ b/src/test/resources/db/changelog/2024-09-06-create-wrapper-type-testing-table.yml
@@ -54,7 +54,7 @@ databaseChangeLog:
                   type: uuid
               - column:
                   name: uuid_value_as_string
-                  type: uuid
+                  type: char(36)
               - column:
                   name: big_decimal_value_class
                   type: double
@@ -96,4 +96,4 @@ databaseChangeLog:
                   type: uuid
               - column:
                   name: uuid_value_class_as_string
-                  type: uuid
+                  type: char(36)


### PR DESCRIPTION
This adds support for using a `WrappedUUIDJavaType` ID, as well as for using it with Jackson and the OpenAPI document.