### PR TITLE
Add numeric type cases to CustomTypeSerializer

### DIFF
--- a/src/main/java/it/aboutbits/springboot/toolbox/jackson/CustomTypeSerializer.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/jackson/CustomTypeSerializer.java
@@ -1,11 +1,14 @@
 package it.aboutbits.springboot.toolbox.jackson;
 
 import it.aboutbits.springboot.toolbox.type.CustomType;
+import it.aboutbits.springboot.toolbox.type.ScaledBigDecimal;
 import org.jspecify.annotations.NullMarked;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.UUID;
 
 @NullMarked
@@ -28,6 +31,15 @@ public class CustomTypeSerializer extends ValueSerializer<CustomType<?>> {
             case String stringValue -> jsonGenerator.writeString(stringValue);
             case UUID uuidValue -> jsonGenerator.writeString(uuidValue.toString());
             case Enum<?> enumValue -> jsonGenerator.writeString(enumValue.name());
+            case Byte numericValue -> jsonGenerator.writeNumber(numericValue);
+            case Short numericValue -> jsonGenerator.writeNumber(numericValue);
+            case Integer numericValue -> jsonGenerator.writeNumber(numericValue);
+            case Long numericValue -> jsonGenerator.writeNumber(numericValue);
+            case Float numericValue -> jsonGenerator.writeNumber(numericValue);
+            case Double numericValue -> jsonGenerator.writeNumber(numericValue);
+            case BigInteger numericValue -> jsonGenerator.writeNumber(numericValue);
+            case BigDecimal numericValue -> jsonGenerator.writeNumber(numericValue);
+            case ScaledBigDecimal numericValue -> jsonGenerator.writeNumber(numericValue.doubleValue());
             default -> jsonGenerator.writeRawValue(String.valueOf(value));
         }
     }


### PR DESCRIPTION
Ported from https://github.com/aboutbits/spring-boot-toolbox/pull/61.

`CustomTypeSerializer.serialize()` was missing explicit handling for numeric types (`Byte`, `Short`, `Integer`, `Long`, `Float`, `Double`, `BigInteger`, `BigDecimal`, `ScaledBigDecimal`). These fell through to the generic `writeRawValue()` branch, causing numeric-wrapped `CustomType<?>` values to be serialized as JSON strings instead of JSON numbers.

This port adds the nine missing `case` branches, each calling `writeNumber()` with the appropriately typed value. The implementation is adapted from the v1 branch fix (PR #61) to the Jackson 3.x API used in `main` (`tools.jackson.*`, `ValueSerializer`, `SerializationContext`, no `throws IOException`). No `case null` branch was added — the value is `@NonNull` per jspecify and the null case is not applicable in this branch.

## Review notes

This PR ports an existing change into this project. Please focus on:
- **Completeness** — are all relevant changes from the source correctly reflected here?
- **Integration** — does the ported code fit into this project's existing patterns, conventions, and call sites?
- **Adaptation** — were any necessary adaptations (naming, imports, framework differences) made correctly?
