### PR TITLE
Extend `ScaledBigDecimal` class with `Number`

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CheckStyle-IDEA" serialisationVersion="2">
-    <checkstyleVersion>10.18.1</checkstyleVersion>
+    <checkstyleVersion>13.4.0</checkstyleVersion>
     <scanScope>JavaOnly</scanScope>
     <option name="thirdPartyClasspath" />
     <option name="activeLocationIds">

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 
     <properties>
         <java.version>25</java.version>
-        <errorprone.version>2.48.0</errorprone.version>
-        <jooq.version>3.20.11</jooq.version>
-        <nullaway.version>0.13.1</nullaway.version>
+        <errorprone.version>2.49.0</errorprone.version>
+        <jooq.version>3.21.2</jooq.version>
+        <nullaway.version>0.13.2</nullaway.version>
     </properties>
 
     <dependencyManagement>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.3</version>
         </dependency>
 
         <!-- Testing -->
@@ -162,13 +162,13 @@
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
-            <version>1.4.1</version>
+            <version>1.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5-api</artifactId>
-            <version>1.4.1</version>
+            <version>1.4.2</version>
             <scope>compile</scope>
         </dependency>
 
@@ -255,7 +255,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>13.3.0</version>
+                        <version>13.4.0</version>
                     </dependency>
                     <dependency>
                         <groupId>it.aboutbits</groupId>

--- a/src/main/java/it/aboutbits/springboot/toolbox/reflection/util/RecordReflectionUtil.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/reflection/util/RecordReflectionUtil.java
@@ -1,5 +1,6 @@
 package it.aboutbits.springboot.toolbox.reflection.util;
 
+import it.aboutbits.springboot.toolbox.type.ScaledBigDecimal;
 import org.jspecify.annotations.NullMarked;
 
 import java.lang.reflect.Constructor;
@@ -31,7 +32,7 @@ public final class RecordReflectionUtil {
             Class<T> recordClass,
             Class<?> type
     ) {
-        if (!recordClass.isRecord()) {
+        if (!recordClass.isRecord() && !ScaledBigDecimal.class.isAssignableFrom(recordClass)) {
             throw new IllegalArgumentException("Class must be a record: " + recordClass.getName());
         }
 

--- a/src/main/java/it/aboutbits/springboot/toolbox/swagger/customization/nested_structure/NestedStructuresCustomizer.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/swagger/customization/nested_structure/NestedStructuresCustomizer.java
@@ -27,7 +27,7 @@ public class NestedStructuresCustomizer implements OpenApiCustomizer {
                                     true
                             ));
                         }
-                    } catch (ClassNotFoundException ignored) {
+                    } catch (ClassNotFoundException _) {
                         // do nothing
                     }
                 }

--- a/src/main/java/it/aboutbits/springboot/toolbox/type/ScaledBigDecimal.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/type/ScaledBigDecimal.java
@@ -1,6 +1,8 @@
 package it.aboutbits.springboot.toolbox.type;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import org.jspecify.annotations.NullMarked;
 
 import java.math.BigDecimal;
@@ -13,17 +15,19 @@ import java.math.RoundingMode;
  * This class provides various constructors for creating instances with different numerical types.
  * It also provides a set of arithmetic operations that return new instances with the appropriate scale and rounding.
  */
-@NullMarked
+@Getter
+@Accessors(fluent = true)
 @SuppressWarnings("unused")
-public record ScaledBigDecimal(
-        BigDecimal value
-) implements CustomType<BigDecimal>, Comparable<ScaledBigDecimal> {
+@NullMarked
+public class ScaledBigDecimal extends Number implements CustomType<BigDecimal>, Comparable<ScaledBigDecimal> {
     private static final MathContext MATH_CONTEXT = new MathContext(15, RoundingMode.HALF_UP);
 
     public static final ScaledBigDecimal ZERO = new ScaledBigDecimal(0);
     public static final ScaledBigDecimal ONE = new ScaledBigDecimal(1);
     public static final ScaledBigDecimal TWO = new ScaledBigDecimal(2);
     public static final ScaledBigDecimal TEN = new ScaledBigDecimal(10);
+
+    private final BigDecimal value;
 
     @SuppressWarnings("unused")
     ScaledBigDecimal(ScaledBigDecimal other) {
@@ -217,8 +221,8 @@ public record ScaledBigDecimal(
             return true;
         }
 
-        if (o instanceof ScaledBigDecimal(BigDecimal other)) {
-            return this.value().compareTo(other) == 0;
+        if (o instanceof ScaledBigDecimal other) {
+            return this.value().compareTo(other.value()) == 0;
         }
 
         return false;


### PR DESCRIPTION
> [!NOTE]
> I will backport this to v1 once this is approved.

The abstract class `java.lang.Number` requires the following methods to be implemented, which we already implemented in `ScaledBigDecimal`, so the contract is already in place.

I hope that strictly using records for custom types, which cannot extends other classes, was not the reason that we did not extend `Number` for `ScaledBigDecimal`.

<img width="742" height="1189" alt="image" src="https://github.com/user-attachments/assets/b6f01a9e-d218-4620-bf53-31196e0faf43" />