### PR TITLE
Add support for `Enum`'s implementing `CustomType<EnumName>`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>it.aboutbits</groupId>
     <artifactId>spring-boot-toolbox</artifactId>
-    <version>2.5.1-RC1</version>
+    <version>2.5.1-RC3</version>
     <description>Utility library for Spring Boot projects.</description>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>it.aboutbits</groupId>
     <artifactId>spring-boot-toolbox</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1-RC1</version>
     <description>Utility library for Spring Boot projects.</description>
     <packaging>jar</packaging>
 

--- a/src/main/java/it/aboutbits/springboot/toolbox/autoconfiguration/web/CustomTypeScanner.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/autoconfiguration/web/CustomTypeScanner.java
@@ -1,6 +1,7 @@
 package it.aboutbits.springboot.toolbox.autoconfiguration.web;
 
 import it.aboutbits.springboot.toolbox.reflection.util.ClassScannerUtil;
+import it.aboutbits.springboot.toolbox.reflection.util.CustomTypeReflectionUtil;
 import it.aboutbits.springboot.toolbox.type.CustomType;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,7 @@ public class CustomTypeScanner {
         this.relevantTypes = findAllCustomTypes(classScanner);
     }
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public static Set<Class<? extends CustomType>> findAllCustomTypes(ClassScannerUtil.ClassScanner classScanner) {
         return classScanner.getSubTypesOf(CustomType.class).stream()
                 .filter(item ->
@@ -50,6 +51,27 @@ public class CustomTypeScanner {
                                         && !Modifier.isAbstract(item.getModifiers())
                                         && !item.isAnnotationPresent(DisableCustomTypeConfiguration.class)
                 )
+                .filter(item -> {
+                    if (item.isEnum()) {
+                        return true;
+                    }
+
+                    try {
+                        var constructor = CustomTypeReflectionUtil.getCustomTypeConstructor((Class<? extends CustomType<?>>) item);
+                        var wrappedType = constructor.getParameterTypes()[0];
+
+                        if (!CustomTypeReflectionUtil.isSupportedWrappedType(wrappedType)) {
+                            log.debug("CustomType {} has an unsupported wrapped type {} and will be ignored.", item.getName(), wrappedType.getName());
+                            return false;
+                        }
+
+                        return true;
+                    } catch (NoSuchMethodException _) {
+                        log.debug("CustomType {} is missing the required constructor and will be ignored.", item.getName());
+
+                        return false;
+                    }
+                })
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/it/aboutbits/springboot/toolbox/jackson/CustomTypeDeserializer.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/jackson/CustomTypeDeserializer.java
@@ -23,24 +23,29 @@ import java.util.function.Function;
 @NullMarked
 public class CustomTypeDeserializer<T extends CustomType<?>> extends ValueDeserializer<T> {
     private final Class<T> customType;
-    private final Constructor<T> constructor;
+    private final @Nullable Constructor<T> constructor;
     private final Function<JsonParser, @Nullable Object> typeConverter;
 
     public CustomTypeDeserializer(Class<T> customType) {
         this.customType = customType;
 
-        try {
-            this.constructor = CustomTypeReflectionUtil.getCustomTypeConstructor(customType);
-        } catch (NoSuchMethodException e) {
-            throw new CustomTypeDeserializerException(
-                    "Unable to find constructor for type: " + customType.getName(),
-                    e
+        if (customType.isEnum()) {
+            this.constructor = null;
+            this.typeConverter = getEnumConverter(customType);
+        } else {
+            try {
+                this.constructor = CustomTypeReflectionUtil.getCustomTypeConstructor(customType);
+            } catch (NoSuchMethodException e) {
+                throw new CustomTypeDeserializerException(
+                        "Unable to find constructor for type: " + customType.getName(),
+                        e
+                );
+            }
+
+            this.typeConverter = getTypeConverter(
+                    constructor.getParameterTypes()[0]
             );
         }
-
-        this.typeConverter = getTypeConverter(
-                constructor.getParameterTypes()[0]
-        );
     }
 
     @Override
@@ -49,8 +54,17 @@ public class CustomTypeDeserializer<T extends CustomType<?>> extends ValueDeseri
     }
 
     @Override
-    public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
+    @SuppressWarnings("unchecked")
+    public @Nullable T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
         var value = typeConverter.apply(jsonParser);
+
+        if (value == null) {
+            return null;
+        }
+
+        if (constructor == null) {
+            return (T) value;
+        }
 
         try {
             return constructor.newInstance(value);

--- a/src/main/java/it/aboutbits/springboot/toolbox/reflection/util/CustomTypeReflectionUtil.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/reflection/util/CustomTypeReflectionUtil.java
@@ -1,11 +1,15 @@
 package it.aboutbits.springboot.toolbox.reflection.util;
 
 import it.aboutbits.springboot.toolbox.type.CustomType;
+import it.aboutbits.springboot.toolbox.type.ScaledBigDecimal;
 import org.jspecify.annotations.NullMarked;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.ParameterizedType;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.UUID;
 
 @NullMarked
 public final class CustomTypeReflectionUtil {
@@ -17,7 +21,7 @@ public final class CustomTypeReflectionUtil {
             return customType.getConstructor(
                     getWrappedType(customType)
             );
-        } catch (NoSuchMethodException | SecurityException e) {
+        } catch (NoSuchMethodException | SecurityException _) {
             throw new NoSuchMethodException();
         }
     }
@@ -42,5 +46,23 @@ public final class CustomTypeReflectionUtil {
         }
 
         throw new NoSuchMethodException();
+    }
+
+    public static boolean isSupportedWrappedType(Class<?> wrappedType) {
+        return Boolean.class.isAssignableFrom(wrappedType)
+                || String.class.isAssignableFrom(wrappedType)
+                || Character.class.isAssignableFrom(wrappedType)
+                || Byte.class.isAssignableFrom(wrappedType)
+                || Short.class.isAssignableFrom(wrappedType)
+                || Integer.class.isAssignableFrom(wrappedType)
+                || Long.class.isAssignableFrom(wrappedType)
+                || Float.class.isAssignableFrom(wrappedType)
+                || Double.class.isAssignableFrom(wrappedType)
+                || BigInteger.class.isAssignableFrom(wrappedType)
+                || BigDecimal.class.isAssignableFrom(wrappedType)
+                || ScaledBigDecimal.class.isAssignableFrom(wrappedType)
+                || UUID.class.isAssignableFrom(wrappedType)
+                || Enum.class.isAssignableFrom(wrappedType)
+                || wrappedType.isEnum();
     }
 }

--- a/src/main/java/it/aboutbits/springboot/toolbox/web/CustomTypePropertyEditor.java
+++ b/src/main/java/it/aboutbits/springboot/toolbox/web/CustomTypePropertyEditor.java
@@ -17,22 +17,27 @@ import java.util.function.Function;
 
 @NullMarked
 public final class CustomTypePropertyEditor<T extends CustomType<?>> extends PropertyEditorSupport {
-    private final Constructor<T> constructor;
+    private final @Nullable Constructor<T> constructor;
     private final Function<@Nullable String, @Nullable Object> typeConverter;
 
     public CustomTypePropertyEditor(Class<T> customType) {
-        try {
-            this.constructor = CustomTypeReflectionUtil.getCustomTypeConstructor(customType);
-        } catch (NoSuchMethodException e) {
-            throw new CustomTypeDeserializer.CustomTypeDeserializerException(
-                    "Unable to find constructor for type: " + customType.getName(),
-                    e
+        if (customType.isEnum()) {
+            this.constructor = null;
+            this.typeConverter = toEnumConverter(customType);
+        } else {
+            try {
+                this.constructor = CustomTypeReflectionUtil.getCustomTypeConstructor(customType);
+            } catch (NoSuchMethodException e) {
+                throw new CustomTypeDeserializer.CustomTypeDeserializerException(
+                        "Unable to find constructor for type: " + customType.getName(),
+                        e
+                );
+            }
+
+            this.typeConverter = getTextToTypeConverter(
+                    constructor.getParameters()[0].getType()
             );
         }
-
-        this.typeConverter = getTextToTypeConverter(
-                constructor.getParameters()[0].getType()
-        );
     }
 
     @SuppressWarnings("unchecked")
@@ -45,8 +50,13 @@ public final class CustomTypePropertyEditor<T extends CustomType<?>> extends Pro
     }
 
     @Override
-    public void setAsText(String text) throws IllegalArgumentException {
+    public void setAsText(@Nullable String text) throws IllegalArgumentException {
         var value = typeConverter.apply(text);
+
+        if (constructor == null) {
+            setValue(value);
+            return;
+        }
 
         try {
             setValue(

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/EntityIdBindingsForControllerTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/EntityIdBindingsForControllerTest.java
@@ -119,6 +119,7 @@ class EntityIdBindingsForControllerTest {
     }
 
     @Nested
+    @ArchIgnoreNoProductionCounterpart
     class DirectEnumEntityIdTest {
         @Test
         void valueAsPathVariable() throws Exception {

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/EntityIdBindingsForControllerTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/EntityIdBindingsForControllerTest.java
@@ -6,6 +6,7 @@ import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithEntity
 import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithEnumEntityId;
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.CustomTypeEnumTestModel;
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.CustomTypeTestModel;
+import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.DirectEnumEntityId;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -112,6 +113,49 @@ class EntityIdBindingsForControllerTest {
             );
 
             var actual = jsonMapper.readValue(resultAsString, BodyWithEnumEntityId.class);
+
+            assertThat(actual).isEqualTo(value);
+        }
+    }
+
+    @Nested
+    class DirectEnumEntityIdTest {
+        @Test
+        void valueAsPathVariable() throws Exception {
+            var value = DirectEnumEntityId.VAL1;
+
+            var resultAsString = performGetAndReturnResult(
+                    String.format("/test/entity-id/DirectEnumEntityId/as-path-variable/%s", value)
+            );
+
+            var actual = jsonMapper.readValue(resultAsString, DirectEnumEntityId.class);
+
+            assertThat(actual).isEqualTo(value);
+        }
+
+        @Test
+        void valueAsRequestParameter() throws Exception {
+            var value = DirectEnumEntityId.VAL2;
+
+            var resultAsString = performGetAndReturnResult(
+                    String.format("/test/entity-id/DirectEnumEntityId/as-request-parameter?value=%s", value)
+            );
+
+            var actual = jsonMapper.readValue(resultAsString, DirectEnumEntityId.class);
+
+            assertThat(actual).isEqualTo(value);
+        }
+
+        @Test
+        void valueAsBody() throws Exception {
+            var value = DirectEnumEntityId.VAL1;
+
+            var resultAsString = performPostAndReturnResult(
+                    "/test/entity-id/DirectEnumEntityId/as-body",
+                    value
+            );
+
+            var actual = jsonMapper.readValue(resultAsString, DirectEnumEntityId.class);
 
             assertThat(actual).isEqualTo(value);
         }

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/controller/EntityIdTestController.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/mvc/controller/EntityIdTestController.java
@@ -4,6 +4,7 @@ import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithEntity
 import it.aboutbits.springboot.toolbox.autoconfiguration.mvc.body.BodyWithEnumEntityId;
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.CustomTypeEnumTestModel;
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.CustomTypeTestModel;
+import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.DirectEnumEntityId;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,6 +45,21 @@ public class EntityIdTestController {
 
     @PostMapping("/CustomTypeEnumTestModel.ID/as-body")
     public BodyWithEnumEntityId customTypeEnumTestModelIdAsBody(@RequestBody BodyWithEnumEntityId value) {
+        return value;
+    }
+
+    @GetMapping("/DirectEnumEntityId/as-path-variable/{value}")
+    public DirectEnumEntityId directEnumEntityIdAsPathVariable(@PathVariable DirectEnumEntityId value) {
+        return value;
+    }
+
+    @GetMapping("/DirectEnumEntityId/as-request-parameter")
+    public DirectEnumEntityId directEnumEntityIdAsRequestParameter(@RequestParam DirectEnumEntityId value) {
+        return value;
+    }
+
+    @PostMapping("/DirectEnumEntityId/as-body")
+    public DirectEnumEntityId directEnumEntityIdAsBody(@RequestBody DirectEnumEntityId value) {
         return value;
     }
 }

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/EntityIdJpaTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/EntityIdJpaTest.java
@@ -7,6 +7,9 @@ import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.Cu
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.CustomTypeEnumTestModelRepository;
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.CustomTypeTestModel;
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.CustomTypeTestModelRepository;
+import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.DirectEnumEntityId;
+import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.DirectEnumIdTestModel;
+import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.DirectEnumIdTestModelRepository;
 import it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa.ReferencedTestModel;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Nested;
@@ -28,10 +31,13 @@ class EntityIdJpaTest {
     @Autowired
     CustomTypeEnumTestModelRepository repositoryEnum;
 
+    @Autowired
+    DirectEnumIdTestModelRepository repositoryDirectEnum;
+
     @Nested
     class OwnId {
         @Test
-        void inAndOut_shouldSucceed() {
+        void ownId_inAndOut_shouldSucceed() {
             var item = new CustomTypeTestModel();
 
             var savedItem = repository.save(item);
@@ -48,7 +54,7 @@ class EntityIdJpaTest {
     @Nested
     class ReferencedId {
         @Test
-        void inAndOut_shouldSucceed() {
+        void referencedId_inAndOut_shouldSucceed() {
             var item = new CustomTypeTestModel();
             item.setReferencedId(new ReferencedTestModel.ID(1234L));
 
@@ -66,7 +72,7 @@ class EntityIdJpaTest {
     @Nested
     class EnumId {
         @Test
-        void inAndOut_shouldSucceed() {
+        void enumId_inAndOut_shouldSucceed() {
             var values = CustomTypeEnumTestModel.CustomTypeEnum.values();
 
             var item = new CustomTypeEnumTestModel();
@@ -77,6 +83,26 @@ class EntityIdJpaTest {
             var savedItem = repositoryEnum.save(item);
 
             var retrievedItem = repositoryEnum.findById(savedItem.getId());
+
+            assertThat(retrievedItem).isPresent()
+                    .get()
+                    .usingRecursiveComparison()
+                    .isEqualTo(savedItem);
+        }
+    }
+
+    @Nested
+    class DirectEnumId {
+        @Test
+        void directEnumId_inAndOut_shouldSucceed() {
+            var values = DirectEnumEntityId.values();
+
+            var item = new DirectEnumIdTestModel();
+            item.setId(values[new Random().nextInt(values.length)]);
+
+            var savedItem = repositoryDirectEnum.save(item);
+
+            var retrievedItem = repositoryDirectEnum.findById(savedItem.getId());
 
             assertThat(retrievedItem).isPresent()
                     .get()

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/DirectEnumEntityId.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/DirectEnumEntityId.java
@@ -1,0 +1,15 @@
+package it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa;
+
+import it.aboutbits.springboot.toolbox.type.identity.EntityId;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public enum DirectEnumEntityId implements EntityId<DirectEnumEntityId> {
+    VAL1,
+    VAL2;
+
+    @Override
+    public DirectEnumEntityId value() {
+        return this;
+    }
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/DirectEnumIdTestModel.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/DirectEnumIdTestModel.java
@@ -1,0 +1,23 @@
+package it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa;
+
+import it.aboutbits.springboot.toolbox.type.identity.Identified;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullUnmarked;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "direct_enum_id_test_model")
+@NullUnmarked
+public class DirectEnumIdTestModel implements Identified<@NonNull DirectEnumEntityId> {
+    @Id
+    @Enumerated(EnumType.STRING)
+    private DirectEnumEntityId id;
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/DirectEnumIdTestModelRepository.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/persistence/impl/jpa/DirectEnumIdTestModelRepository.java
@@ -1,0 +1,8 @@
+package it.aboutbits.springboot.toolbox.autoconfiguration.persistence.impl.jpa;
+
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@NullMarked
+public interface DirectEnumIdTestModelRepository extends JpaRepository<DirectEnumIdTestModel, DirectEnumEntityId> {
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/web/CustomTypeScannerTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/autoconfiguration/web/CustomTypeScannerTest.java
@@ -1,0 +1,67 @@
+package it.aboutbits.springboot.toolbox.autoconfiguration.web;
+
+import it.aboutbits.springboot.toolbox.reflection.util.ClassScannerUtil;
+import it.aboutbits.springboot.toolbox.type.CustomType;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@NullMarked
+class CustomTypeScannerTest {
+    @Test
+    @SuppressWarnings("unchecked")
+    void findAllCustomTypes_shouldFilterOutTypesMissingConstructor() {
+        // given
+        ClassScannerUtil.ClassScanner classScanner = mock(ClassScannerUtil.ClassScanner.class);
+        when(classScanner.getSubTypesOf(CustomType.class)).thenReturn(Set.of(
+                EnumCustomType.class,
+                InvalidCustomType.class,
+                UnsupportedWrappedTypeCustomType.class
+        ));
+
+        // when
+        Set<Class<? extends CustomType>> result = CustomTypeScanner.findAllCustomTypes(classScanner);
+
+        // then
+        assertThat(result)
+                .containsExactly(EnumCustomType.class)
+                .doesNotContain(InvalidCustomType.class)
+                .doesNotContain(UnsupportedWrappedTypeCustomType.class);
+    }
+
+    public enum EnumCustomType implements CustomType<EnumCustomType> {
+        VALUE;
+
+        @Override
+        public EnumCustomType value() {
+            return this;
+        }
+    }
+
+    @SuppressWarnings("checkstyle:RedundantModifier")
+    public static class InvalidCustomType implements CustomType<String> {
+        @Override
+        public String value() {
+            return "test";
+        }
+    }
+
+    @SuppressWarnings("checkstyle:RedundantModifier")
+    public static class UnsupportedWrappedTypeCustomType implements CustomType<Object> {
+        private final Object value;
+
+        public UnsupportedWrappedTypeCustomType(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public Object value() {
+            return value;
+        }
+    }
+}

--- a/src/test/java/it/aboutbits/springboot/toolbox/jackson/CustomTypeDeserializerTest.java
+++ b/src/test/java/it/aboutbits/springboot/toolbox/jackson/CustomTypeDeserializerTest.java
@@ -1,0 +1,44 @@
+package it.aboutbits.springboot.toolbox.jackson;
+
+import it.aboutbits.springboot.toolbox.type.CustomType;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@NullMarked
+class CustomTypeDeserializerTest {
+    @Test
+    void constructor_withValidCustomType_shouldNotThrow() {
+        assertThatCode(() -> new CustomTypeDeserializer<>(EnumCustomType.class))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void constructor_withInvalidCustomType_shouldThrowException() {
+        assertThatExceptionOfType(CustomTypeDeserializer.CustomTypeDeserializerException.class)
+                .isThrownBy(() -> new CustomTypeDeserializer<>(InvalidCustomType.class))
+                .withMessageContaining(
+                        "Unable to find constructor for type: it.aboutbits.springboot.toolbox.jackson.CustomTypeDeserializerTest$InvalidCustomType"
+                );
+    }
+
+    public enum EnumCustomType implements CustomType<EnumCustomType> {
+        VALUE;
+
+        @Override
+        public EnumCustomType value() {
+            return this;
+        }
+    }
+
+    @SuppressWarnings("checkstyle:RedundantModifier")
+    public static class InvalidCustomType implements CustomType<String> {
+        @Override
+        public String value() {
+            return "test";
+        }
+        // Missing constructor(String)
+    }
+}

--- a/src/test/resources/db/changelog/2026-05-06-create-direct-enum-id-test-model-table.yml
+++ b/src/test/resources/db/changelog/2026-05-06-create-direct-enum-id-test-model-table.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      author: Junie
+      id: 2026-05-06-create-direct-enum-id-test-model-table
+      changes:
+        - createTable:
+            tableName: direct_enum_id_test_model
+            columns:
+              - column:
+                  name: id
+                  type: text
+                  constraints:
+                    nullable: false
+                    primaryKey: true

--- a/src/test/resources/db/changelog/2026-05-06-create-direct-enum-id-test-model-table.yml
+++ b/src/test/resources/db/changelog/2026-05-06-create-direct-enum-id-test-model-table.yml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      author: Junie
+      author: Thomas Sapelza
       id: 2026-05-06-create-direct-enum-id-test-model-table
       changes:
         - createTable:

--- a/src/test/resources/db/changelog/master.yml
+++ b/src/test/resources/db/changelog/master.yml
@@ -11,3 +11,6 @@ databaseChangeLog:
   - include:
       file: 2025-08-29-create-custom-type-enum-testing-table.yml
       relativeToChangelogFile: true
+  - include:
+      file: 2026-05-06-create-direct-enum-id-test-model-table.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
In Finstral, we have a case where the Enum is the `EntityId` (e.g. `CustomType`) -> for example the `Authority` enum